### PR TITLE
Added aks existing vnet sample bicep files

### DIFF
--- a/infra/templates/aks_existing_vnet/aks.bicep
+++ b/infra/templates/aks_existing_vnet/aks.bicep
@@ -1,0 +1,99 @@
+param clusterName string
+param location string
+param nodeResourceGroup string
+param aksIdentityResourceId string
+param dnsPrefix string = toLower(clusterName)
+param logAnalyticsWorkspaceId string
+param aksSubnetId string
+@description('Specifies the CIDR notation IP range from which to assign pod IPs when kubenet is used.')
+param podCidr string = '10.244.0.0/16'
+@description('A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.')
+param serviceCidr string = '10.240.0.0/16'
+@description('Specifies the IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.')
+param dnsServiceIP string = '10.240.0.10'
+@description('Specifies the CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range.')
+param dockerBridgeCidr string = '172.17.0.1/16'
+param aksnetworktype string
+
+
+resource aks 'Microsoft.ContainerService/managedClusters@2022-08-03-preview' = {
+  name: clusterName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${aksIdentityResourceId}': {}
+    }
+  }
+  properties: {
+    nodeResourceGroup: nodeResourceGroup
+    dnsPrefix: dnsPrefix
+    oidcIssuerProfile:{
+      enabled:true
+    }
+
+    agentPoolProfiles: [
+      {
+        name: 'system'
+        count: 1
+        enableAutoScaling: false
+        vmSize: 'Standard_D4s_v4'
+        osType: 'Linux'
+        osDiskType: 'Managed'
+        mode: 'System'
+        type: 'VirtualMachineScaleSets'
+        availabilityZones: [
+          '1'
+          '2'
+        ]
+        vnetSubnetID: aksSubnetId
+        nodeTaints: [
+          'CriticalAddonsOnly=true:NoSchedule'
+        ]
+      }
+      {
+        name: 'application'
+        count: 2
+        maxPods: 15
+        enableAutoScaling: false
+        vmSize: 'Standard_D4s_v4'
+        osType: 'Linux'
+        osDiskType: 'Managed'
+        mode: 'User'
+        type: 'VirtualMachineScaleSets'
+        availabilityZones: [
+          '1'
+          '2'
+        ]
+        vnetSubnetID: aksSubnetId
+        nodeTaints: []
+      }
+    ]
+    addonProfiles: {
+      omsagent: {
+        enabled: true
+        config: {
+          logAnalyticsWorkspaceResourceID: logAnalyticsWorkspaceId
+        }
+      }
+    }
+    enableRBAC: true
+    networkProfile: {
+      networkPlugin: aksnetworktype
+      podCidr: podCidr
+      serviceCidr: serviceCidr
+      dnsServiceIP: dnsServiceIP
+      dockerBridgeCidr: dockerBridgeCidr
+      loadBalancerSku: 'standard'
+    }
+    securityProfile:{
+      workloadIdentity:{
+        enabled:true
+      }
+    }
+  }
+}
+
+output aksClusterName string = aks.name
+output aksNodeResourceGroup string = aks.properties.nodeResourceGroup
+output aksKubeletIdentityObjectId string = aks.properties.identityProfile.kubeletidentity.objectId

--- a/infra/templates/aks_existing_vnet/createUiDefinition.json
+++ b/infra/templates/aks_existing_vnet/createUiDefinition.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+  "handler": "Microsoft.Azure.CreateUIDef",
+  "version": "0.1.2-preview",
+  "parameters": {
+    "config": {
+      "isWizard": true,
+      "basics": {
+        "subscription": {
+          "constraints": {
+            "validations": []
+          },
+          "resourceProviders": [
+            "Microsoft.Compute"
+          ]
+        },
+        "location": {
+          "allowedValues": [],
+          "visible": true
+        },
+        "resourceGroup": {
+          "constraints": {
+            "validations": [
+              {
+                "permission": "Microsoft.ContainerService/managedClusters/write",
+                "message": "Must have permission to create AKS clusters."
+              },
+              {
+                "permission": "Microsoft.OperationalInsights/workspaces/write",
+                "message": "Must have permission to create Log Analytics workspaces."
+              },
+              {
+                "permission": "Microsoft.Network/virtualNetworks/subnets/write",
+                "message": "Must have permission to create subnets."
+              },
+              {
+                "permission": "Microsoft.Network/virtualNetworks/write",
+                "message": "Must have permission to create virtual networks."
+              },
+              {
+                "permission": "Microsoft.Resources/deployments/write",
+                "message": "Must have permission to create deployments."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "basics": [],
+    "steps": [
+      {
+        "name": "nwConfig",
+        "label": "Networking",
+        "elements": [
+          {
+            "name": "infoMessage",
+            "type": "Microsoft.Common.InfoBox",
+            "visible": true,
+            "options": {
+              "icon": "Info",
+              "text": "Please enter your required Network Configuration options"
+            }
+          },
+          {
+            "name": "vnetConfig",
+            "type": "Microsoft.Network.VirtualNetworkCombo",
+            "label": {
+              "virtualNetwork": "Virtual network",
+              "subnets": "Subnets"
+            },
+            "toolTip": {
+              "virtualNetwork": "Select or Create the required VNet",
+              "subnets": "Select or create the required subnets"
+            },
+            "defaultValue": {
+              "name": "demo-vnet",
+              "addressPrefixSize": "/23"
+            },
+            "constraints": {
+              "minAddressPrefixSize": "/23"
+            },
+            "options": {
+              "hideExisting": false
+            },
+            "subnets": {
+              "subnet1": {
+                "label": "AKS Subnet",
+                "defaultValue": {
+                  "name": "aks-subnet",
+                  "addressPrefixSize": "/25"
+                },
+                "constraints": {
+                  "minAddressPrefixSize": "/25",
+                  "requireContiguousAddresses": true
+                }
+              },
+              "subnet2": {
+                "label": "Virtual Machine Subnet",
+                "defaultValue": {
+                  "name": "vm-subnet",
+                  "addressPrefixSize": "/26"
+                },
+                "constraints": {
+                  "minAddressPrefixSize": "/26",
+                  "requireContiguousAddresses": true
+                }
+              }
+            },
+            "visible": true
+          },
+          {
+            "name": "aksnetworktype",
+            "type": "Microsoft.Common.OptionsGroup",
+            "label": "Azure Kubernetes Networking Type",
+            "defaultValue": "Azure",
+            "toolTip": "AKS network type",
+            "constraints": {
+              "allowedValues": [
+                {
+                  "label": "Azure",
+                  "value": "azure"
+                },
+                {
+                  "label": "Kubenet",
+                  "value": "kubenet"
+                }
+              ],
+              "required": true
+            },
+            "visible": true
+          }
+        ]
+      },
+      {
+        "name": "projectOptions",
+        "label": "Project Options",
+        "elements": [
+          {
+            "name": "infraMessage",
+            "type": "Microsoft.Common.InfoBox",
+            "visible": true,
+            "options": {
+              "icon": "Info",
+              "text": "Please enter your required infrastructure options"
+            }
+          },
+          {
+            "name": "projectName",
+            "type": "Microsoft.Common.TextBox",
+            "label": "Azure resources prefix",
+            "placeholder": "",
+            "defaultValue": "demo",
+            "toolTip": "Use only the allowed characters",
+            "constraints": {
+              "required": true,
+              "regex": "^[a-z0-9A-Z]{1,10}$",
+              "validationMessage": "Only alphanumeric characters are allowed, and the value must be 1-10 characters long."
+            },
+            "visible": true
+          }
+        ]
+      },
+      {
+        "name": "tags",
+        "label": "Tags",
+        "elements": [
+          {
+            "name": "tagsByResource",
+            "toolTip": "Enter required Tags",
+            "type": "Microsoft.Common.TagsByResource",
+            "resources": [
+              "Microsoft.Compute/virtualMachines"
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": {
+      "virtualNetworkNewOrExisting": "[steps('nwConfig').vnetConfig.newOrExisting]",
+      "virtualNetworkName": "[steps('nwConfig').vnetConfig.name]",
+      "virtualNetworkAddressPrefix": "[steps('nwConfig').vnetConfig.addressPrefixes]",
+      "virtualNetworkResourceGroup": "[steps('nwConfig').vnetConfig.resourceGroup]",
+      "aksSubnetAddressPrefix": "[steps('nwConfig').vnetConfig.subnets.subnet1.addressPrefix]",
+      "vmSubnetAddressPrefix": "[steps('nwConfig').vnetConfig.subnets.subnet2.addressPrefix]",
+      "aksSubnetName": "[steps('nwConfig').vnetConfig.subnets.subnet1.name]",
+      "vmSubnetName": "[steps('nwConfig').vnetConfig.subnets.subnet2.name]",
+      "projectName": "[steps('projectOptions').projectName]",
+      "tags": "[steps('tags').tagsByResource]",
+      "location": "[location()]"
+    }
+  }
+}

--- a/infra/templates/aks_existing_vnet/identity.bicep
+++ b/infra/templates/aks_existing_vnet/identity.bicep
@@ -1,0 +1,15 @@
+param appName string
+param location string
+
+var resgpguid = substring(replace(guid(resourceGroup().id), '-', ''), 0, 4)
+var uniqueResourceName_var = '${appName}${resgpguid}'
+
+resource aksIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: '${uniqueResourceName_var}aksIdentity'
+  location: location
+}
+
+output aksIdentityObjectId string = aksIdentity.properties.principalId
+output aksIdentityTenantId string = aksIdentity.properties.tenantId
+output aksIdentityResourceId string = aksIdentity.id
+

--- a/infra/templates/aks_existing_vnet/main.bicep
+++ b/infra/templates/aks_existing_vnet/main.bicep
@@ -1,0 +1,177 @@
+targetScope = 'resourceGroup'
+
+param location string = resourceGroup().location
+
+// Marketplace
+param marketplaceAttributionIdPlaceholder string = newGuid()
+
+// Virtual network
+
+@description('Boolean indicating whether the VNet is new or existing')
+param virtualNetworkNewOrExisting string = 'new'
+@description('Existing VNet Name')
+param virtualNetworkName string = 'rtc-vnet'
+
+@description('Resource group of the VNet')
+param virtualNetworkResourceGroup string = resourceGroup().name
+
+@description('Application subnet Name')
+param vmSubnetName string = 'vm-subnet'
+
+@description('AKS subnet Name')
+param aksSubnetName string = 'aks-subnet'
+
+@description('Address Prefix of the Vnet')
+param virtualNetworkAddressPrefix array = [
+  '10.3.0.0/22'
+]
+
+@description('Subnet Address Prefix')
+param aksSubnetAddressPrefix string = '10.3.0.0/24'
+
+@description('Subnet Address Prefix')
+param vmSubnetAddressPrefix string = '10.3.3.0/27'
+
+param aksNodeResourceGroup string = '${resourceGroup().name}-aks'
+
+// AKS
+
+param aksnetworktype string = 'azure'
+param projectName string = 'demo'
+
+var aksClusterName = '${projectName}-aks'
+
+
+var vnets = ( virtualNetworkNewOrExisting == 'new' ) ?  [
+  {
+    name: '${projectName}-vnet'
+    addressPrefix: virtualNetworkAddressPrefix[0]
+    subnets: [
+      {
+        name: vmSubnetName
+        addressPrefix: vmSubnetAddressPrefix
+        delegations: []
+        nsg: {
+          id: nsg.outputs.networkSecurityGroupId
+        }
+      }
+      {
+        name: aksSubnetName
+        addressPrefix: aksSubnetAddressPrefix
+        delegations: []
+        nsg: json('null')
+      }
+    ]
+  }
+] : [
+  {
+    name: virtualNetworkName
+    addressPrefix: virtualNetworkAddressPrefix[0]
+    subnets: [
+      {
+        name: vmSubnetName
+        addressPrefix: vmSubnetAddressPrefix
+      }
+      {
+        name: aksSubnetName
+        addressPrefix: aksSubnetAddressPrefix
+      }
+    ]
+  }
+]
+
+var nsgRules = (virtualNetworkNewOrExisting == 'new') ? [
+  {
+    name: 'SSH'
+    properties: {
+      priority: 300
+      protocol: 'TCP'
+      access: 'Allow'
+      direction: 'Inbound'
+      sourceAddressPrefix: '*'
+      sourcePortRange: '*'
+      destinationAddressPrefix: '*'
+      destinationPortRange: 22
+    }
+  }
+]:[]
+
+resource marketplaceAttribution 'Microsoft.Resources/deployments@2021-04-01' = {
+  name: marketplaceAttributionIdPlaceholder
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+    }
+  }
+}
+
+module vnet 'vnets.bicep' = if (virtualNetworkNewOrExisting == 'new') {
+  name: '${projectName}Vnet'
+  params: {
+    vnets: vnets
+  }
+}
+
+
+resource loganalytics 'Microsoft.OperationalInsights/workspaces@2021-06-01' = {
+  name: '${projectName}LogAnalytics'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 60
+  }
+}
+
+module nsg 'nsg.bicep' = if (virtualNetworkNewOrExisting == 'new') {
+  name: '${projectName}NetworkSecurityGroup'
+  params: {
+    networkSecurityGroupRules: nsgRules
+    projectName: projectName
+    location: location
+  }
+}
+
+module identity 'identity.bicep' = {
+  name: '${projectName}Identity'
+  params: {
+    appName: projectName
+    location: location
+  }
+}
+
+module aks 'aks.bicep' = {
+  name: '${projectName}Aks'
+  params: {
+    location: location
+    clusterName: aksClusterName
+    aksIdentityResourceId: identity.outputs.aksIdentityResourceId
+    nodeResourceGroup: aksNodeResourceGroup
+    aksSubnetId: resourceId('Microsoft.Network/virtualNetworks/subnets', vnets[0].name, aksSubnetName)
+    logAnalyticsWorkspaceId: loganalytics.id
+    aksnetworktype: aksnetworktype
+  }
+  dependsOn: [
+    vnet
+  ]
+}
+
+module roleassignment 'role-assignment.bicep' = {
+  name: '${projectName}RoleAssignment'
+  params: {
+    aksIdentityObjectId: identity.outputs.aksIdentityObjectId
+    aksKubeletIdentityObjectId: aks.outputs.aksKubeletIdentityObjectId
+  }
+}
+
+module roleassignmentAks 'role-assignment-aks.bicep' = {
+  name: '${projectName}RoleAssignmentAks'
+  scope: resourceGroup(aksNodeResourceGroup)
+  params: {
+    aksKubeletIdentityObjectId: aks.outputs.aksKubeletIdentityObjectId
+  }
+}

--- a/infra/templates/aks_existing_vnet/nsg.bicep
+++ b/infra/templates/aks_existing_vnet/nsg.bicep
@@ -1,0 +1,29 @@
+@description('projectName used to make this deployment unique')
+param projectName string = 'demo'
+param location string = resourceGroup().location
+param networkSecurityGroupName string = '${projectName}-nsg'
+param networkSecurityGroupRules array = [
+  {
+    name: 'AllowSSH'
+    properties: {
+      priority: 100
+      protocol: 'Tcp'
+      access: 'Allow'
+      direction: 'Inbound'
+      sourceAddressPrefix: '*'
+      sourcePortRange: '*'
+      destinationAddressPrefix: '*'
+      destinationPortRange: '22'
+    }
+  }
+]
+
+resource networkSecurityGroupName_resource 'Microsoft.Network/networkSecurityGroups@2019-02-01' = {
+  name: networkSecurityGroupName
+  location: location
+  properties: {
+    securityRules: networkSecurityGroupRules
+  }
+}
+
+output networkSecurityGroupId string = networkSecurityGroupName_resource.id

--- a/infra/templates/aks_existing_vnet/role-assignment-aks.bicep
+++ b/infra/templates/aks_existing_vnet/role-assignment-aks.bicep
@@ -1,0 +1,15 @@
+param aksKubeletIdentityObjectId string
+
+var virtualMachineContributorRole = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')
+
+
+// This role assignment allows the Kubelet identity to attach identities to the VMSS instances (needed by AAD Pod Identity)
+resource kubeletIdentityVirtualMachineContributor 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid('kubeletIdentityVirtualMachineContributor', resourceGroup().id)
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: virtualMachineContributorRole
+    principalId: aksKubeletIdentityObjectId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infra/templates/aks_existing_vnet/role-assignment.bicep
+++ b/infra/templates/aks_existing_vnet/role-assignment.bicep
@@ -1,0 +1,29 @@
+param aksIdentityObjectId string
+param aksKubeletIdentityObjectId string
+
+
+var networkContributorRole = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')
+var managedIdentityOperatorRole = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830')
+
+resource aksIdentityNetworkContributor 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid('aksIdentityNetworkContributor', resourceGroup().id)
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: networkContributorRole
+    principalId: aksIdentityObjectId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+
+//This Role Assignment allows the Kubelet Identity to assign the other identities to the AKS nodes (needed by AAD Pod Identity)
+resource kubeletIdentityManagedIdentityOperator 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid('kubeletIdentityManagedIdentityOperator', resourceGroup().id)
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: managedIdentityOperatorRole
+    principalId: aksKubeletIdentityObjectId
+    principalType: 'ServicePrincipal'
+  }
+}
+

--- a/infra/templates/aks_existing_vnet/vnets.bicep
+++ b/infra/templates/aks_existing_vnet/vnets.bicep
@@ -1,0 +1,22 @@
+targetScope = 'resourceGroup'
+param vnets array
+
+resource vnets_name 'Microsoft.Network/virtualNetworks@2021-02-01' = [for i in range(0, length(vnets)): {
+  name: vnets[i].name
+  location: resourceGroup().location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnets[i].addressPrefix
+      ]
+    }
+    subnets: [for j in range(0, length(vnets[i].subnets)): {
+      name: vnets[i].subnets[j].name
+      properties: {
+        addressPrefix: vnets[i].subnets[j].addressPrefix
+        delegations: vnets[i].subnets[j].delegations
+        networkSecurityGroup: vnets[i].subnets[j].nsg
+      }
+    }]
+  }
+}]


### PR DESCRIPTION
Added an example which supports the use of a new or existing vnet.  The sample has been trimmed to deploy AKS, loganalytics and the required networking - no other compute is included.
The customUi def includes examples of resourceProvider check and contraints on the permissions needed to deploy